### PR TITLE
Fix incorrect build flag comment in gpu.rs

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,5 +1,5 @@
 //! GPU inference backend using wgpu compute shaders.
-//! Compiled only with `--features gpu`.
+//! Compiled when the `gpu` feature is enabled (on by default).
 
 use anyhow::{bail, Context, Result};
 use std::collections::HashMap;


### PR DESCRIPTION
The gpu feature is enabled by default, so the old comment
"Compiled only with --features gpu" was misleading.

https://claude.ai/code/session_01TaGTYoi89Kjchn9LeXTtbb